### PR TITLE
Add test to ensure seed length, otherwise key might not be deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ console.log('message was verified', verified)
 
 #### `keys = signatures.keyPair([seed])`
 
-Generate a public key and a secret key, optionally using a 32 byte `seed`
+Generate a public key and a secret key, optionally using a 32-byte `seed`
+(`crypto_sign_SEEDBYTES` defines this length)
 
 #### `signature = signature.sign(message, secretKey)`
 

--- a/browser.js
+++ b/browser.js
@@ -5,6 +5,10 @@ exports.keyPair = function (seed) {
   var secretKey = Buffer(tweetnacl.lowlevel.crypto_sign_SECRETKEYBYTES)
 
   if (seed) {
+    if (seed.length !== tweetnacl.lowlevel.crypto_sign_SEEDBYTES) {
+      throw new Error('Seed must be ' + tweetnacl.lowlevel.crypto_sign_SEEDBYTES + ' bytes long')
+    }
+
     secretKey.fill(seed, 0, seed.length)
     tweetnacl.lowlevel.crypto_sign_keypair(publicKey, secretKey, true)
   } else {

--- a/sodium.js
+++ b/sodium.js
@@ -1,7 +1,13 @@
 var sodium = require('sodium-prebuilt').api
 
 exports.keyPair = function (seed) {
-  if (seed) return sodium.crypto_sign_seed_keypair(seed)
+  if (seed) {
+    if (seed.length !== sodium.crypto_sign_SEEDBYTES) {
+      throw new Error('Seed must be ' + sodium.crypto_sign_SEEDBYTES + ' bytes long')
+    }
+
+    return sodium.crypto_sign_seed_keypair(seed)
+  }
   return sodium.crypto_sign_keypair()
 }
 

--- a/test.js
+++ b/test.js
@@ -33,3 +33,10 @@ tape('sign and verify with seed', function (t) {
   t.ok(signatures.verify(message, sig, keys2.publicKey), 'message verifies')
   t.end()
 })
+
+tape('throws on seed not crypto_sign_SEEDBYTES long', function (t) {
+  t.throws(function () { signatures.keyPair(Buffer(31)) })
+  t.throws(function () { signatures.keyPair(Buffer(33)) })
+
+  t.end()
+})


### PR DESCRIPTION
Note that this PR will not pass tests since `require('sodium-prebuilt').api.crypto_sign_SEEDBYTES` does not exist

Should it just be hardcoded or?
